### PR TITLE
CLD-8538: Calculate passing rate with pass and fail results only

### DIFF
--- a/components/cycle_list.tsx
+++ b/components/cycle_list.tsx
@@ -51,7 +51,7 @@ function CycleList({ cycles }: Props) {
                 } = cycle;
 
                 const end = endAt || updateAt;
-                const { totalCases, passingRate, color } = getCycleSummary(cycle);
+                const { passAndFail, passingRate, color } = getCycleSummary(cycle);
                 const formattedStartDate = formatDate(startAt);
                 const formattedDuration = formatDuration({
                     startAt,
@@ -74,10 +74,10 @@ function CycleList({ cycles }: Props) {
                                             <span>
                                                 {specs_done} / {specs_registered} specs
                                             </span>
-                                            {startAt && totalCases > 0 && (
+                                            {startAt && passAndFail > 0 && (
                                                 <span className={`text-${color}`}>
-                                                    {pass} / {totalCases} cases passed{' '}
-                                                    {totalCases
+                                                    {pass} / {passAndFail} cases passed{' '}
+                                                    {passAndFail
                                                         ? `(${passingRate}%)` // prettier-ignore
                                                         : ''}
                                                 </span>

--- a/lib/common_utils.ts
+++ b/lib/common_utils.ts
@@ -33,7 +33,11 @@ export function getCycleSummary(cycle: Cycle) {
     const { pass, fail, pending, skipped } = cycle;
 
     const totalCases = pass + fail + pending + skipped;
-    const passingRate = totalCases ? (pass / totalCases) * 100 : 0;
+
+    // The passing rate is calculated based solely on pass and fail outcomes,
+    // excluding known and flaky issues, pending and skipped status.
+    const passAndFail = pass + fail;
+    const passingRate = passAndFail ? (pass / passAndFail) * 100 : 0;
 
     let color;
     let hexColor;

--- a/lib/common_utils.ts
+++ b/lib/common_utils.ts
@@ -54,6 +54,7 @@ export function getCycleSummary(cycle: Cycle) {
         fail,
         passingRate: passingRate.toFixed(2),
         passingRateNumber: passingRate,
+        passAndFail,
         color,
         hexColor,
     };


### PR DESCRIPTION
With this change, the passing rate is calculated based solely on pass and fail outcomes, excluding known and flaky issues, pending and skipped status.