### PR TITLE
Add two flaky tests identified in PR #30455

### DIFF
--- a/data/known_issue/onprem-ent.json
+++ b/data/known_issue/onprem-ent.json
@@ -7,5 +7,23 @@
                 "type": "flaky"
             }
         ]
+    },
+    {
+        "spec_file": "tests/integration/channels/collapsed_reply_threads/unread_spec.ts",
+        "cases": [
+            {
+                "title": "MM-T5671 should handle mention counts correctly when marking a thread as unread and unfollowing it",
+                "type": "flaky"
+            }
+        ]
+    },
+    {
+        "spec_file": "tests/integration/playbooks/channels/general_actions_spec.js",
+        "cases": [
+            {
+                "title": "action settings are disabled for non-channel admin",
+                "type": "flaky"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
During [that PR](https://github.com/mattermost/mattermost/pull/30455), E2E tests were ran twice against commit df561f9. In [the first run](https://automation-dashboard.vercel.app/cycle/13859513327_1-df561f9-pr-onprem-ent), the only test that failed was 'action settings are disabled for non-channel admin'; in [the second run](https://automation-dashboard.vercel.app/cycle/13861853096_1-df561f9-pr-onprem-ent), the only test that failed was 'MM-T5671 should handle mention counts correctly when marking a thread as unread and unfollowing it'. Thus, I'm marking both as flaky here.